### PR TITLE
Integración auth service

### DIFF
--- a/src/main/java/com/customer/api/configuration/RestTemplateConfig.java
+++ b/src/main/java/com/customer/api/configuration/RestTemplateConfig.java
@@ -1,0 +1,15 @@
+package com.customer.api.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+	
+	@Bean
+	RestTemplate restTemplate() {
+		return new RestTemplate();
+	}
+
+}

--- a/src/main/java/com/customer/api/controller/CtrlAuth.java
+++ b/src/main/java/com/customer/api/controller/CtrlAuth.java
@@ -1,0 +1,27 @@
+package com.customer.api.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.customer.api.dto.in.AuthRequest;
+import com.customer.api.dto.out.AuthAPIResponse;
+import com.customer.api.service.SvcAuth;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/secured")
+public class CtrlAuth {
+	
+	@Autowired
+	SvcAuth authSvc;
+	
+	@PostMapping(value = "/usuario")
+	public AuthAPIResponse consultaUsuariosRegistrados(@Valid @RequestBody AuthRequest request) throws InterruptedException {
+		return authSvc.consultaUsuarios(request);
+	}
+
+}

--- a/src/main/java/com/customer/api/dto/in/AuthRequest.java
+++ b/src/main/java/com/customer/api/dto/in/AuthRequest.java
@@ -1,0 +1,67 @@
+package com.customer.api.dto.in;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+@AuthRequestConstraint
+public class AuthRequest {
+	
+	private static final Logger log = LoggerFactory.getLogger(AuthRequest.class);
+	
+	private String nombreUsuario;
+	
+	@Email
+	private String correo;
+	
+	@NotBlank
+	private String contrasena;
+	
+	public AuthRequest() {
+		super();		
+	}
+
+	public AuthRequest(String nombreUsuario, String correo, String contrasena) {
+		super();
+		this.nombreUsuario = nombreUsuario;
+		this.correo = correo;
+		this.contrasena = contrasena;
+	}
+	
+	
+	public String getNombreUsuario() {
+		return nombreUsuario;
+	}
+	public void setNombreUsuario(String nombreUsuario) {
+		this.nombreUsuario = nombreUsuario;
+	}
+	public String getCorreo() {
+		return correo;
+	}
+	public void setCorreo(String correo) {
+		this.correo = correo;
+	}
+	public String getContrasena() {
+		return contrasena;
+	}
+	public void setContrasena(String contrasena) {
+		this.contrasena = contrasena;
+	}
+	
+	@Override
+    public String toString() {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            return objectMapper.writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+        	log.error("Excepción atrapada al serializar objeto: {} ", e.getMessage());
+        	return super.toString(); 
+        }
+    }
+
+}

--- a/src/main/java/com/customer/api/dto/in/AuthRequestConstraint.java
+++ b/src/main/java/com/customer/api/dto/in/AuthRequestConstraint.java
@@ -1,0 +1,18 @@
+package com.customer.api.dto.in;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Constraint(validatedBy = AuthRequestValidator.class)
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthRequestConstraint {
+	String message() default "La solicitud no cumple con la especificación requerida";
+	Class<?>[] groups() default {};
+	Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/customer/api/dto/in/AuthRequestValidator.java
+++ b/src/main/java/com/customer/api/dto/in/AuthRequestValidator.java
@@ -1,0 +1,15 @@
+package com.customer.api.dto.in;
+
+import org.springframework.util.StringUtils;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class AuthRequestValidator implements ConstraintValidator<AuthRequestConstraint, AuthRequest>{
+
+	@Override
+	public boolean isValid(AuthRequest request, ConstraintValidatorContext context) {
+		return StringUtils.hasLength(request.getCorreo()) || StringUtils.hasLength(request.getNombreUsuario());
+	}
+
+}

--- a/src/main/java/com/customer/api/dto/in/InfoPaginacion.java
+++ b/src/main/java/com/customer/api/dto/in/InfoPaginacion.java
@@ -1,0 +1,91 @@
+package com.customer.api.dto.in;
+
+import java.io.Serializable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+
+@JsonInclude(Include.NON_EMPTY)
+public class InfoPaginacion implements Serializable{
+
+	private static final long serialVersionUID = 1502769119951843826L;
+	
+	private static final Logger log = LoggerFactory.getLogger(InfoPaginacion.class);
+	
+	private Integer paginaActual;
+	private Boolean paginaSiguiente;
+	private Boolean paginaAnterior;
+	private Integer paginasTotales;
+	private Integer registrosDevueltos;
+	private Long registrosTotales;
+	
+	public InfoPaginacion() {
+		super();
+	}
+
+	public InfoPaginacion(Integer paginaActual, Boolean paginaSiguiente, Boolean paginaAnterior, Integer paginasTotales,
+			Integer registrosDevueltos, Long registrosTotales) {
+		super();
+		this.paginaActual = paginaActual;
+		this.paginaSiguiente = paginaSiguiente;
+		this.paginaAnterior = paginaAnterior;
+		this.paginasTotales = paginasTotales;
+		this.registrosDevueltos = registrosDevueltos;
+		this.registrosTotales = registrosTotales;
+	}
+	
+	public Integer getPaginaActual() {
+		return paginaActual;
+	}
+	public void setPaginaActual(Integer paginaActual) {
+		this.paginaActual = paginaActual;
+	}
+	public Boolean getPaginaSiguiente() {
+		return paginaSiguiente;
+	}
+	public void setPaginaSiguiente(Boolean paginaSiguiente) {
+		this.paginaSiguiente = paginaSiguiente;
+	}
+	public Boolean getPaginaAnterior() {
+		return paginaAnterior;
+	}
+	public void setPaginaAnterior(Boolean paginaAnterior) {
+		this.paginaAnterior = paginaAnterior;
+	}
+	public Integer getPaginasTotales() {
+		return paginasTotales;
+	}
+	public void setPaginasTotales(Integer paginasTotales) {
+		this.paginasTotales = paginasTotales;
+	}
+	public Integer getRegistrosDevueltos() {
+		return registrosDevueltos;
+	}
+	public void setRegistrosDevueltos(Integer registrosDevueltos) {
+		this.registrosDevueltos = registrosDevueltos;
+	}
+	public Long getRegistrosTotales() {
+		return registrosTotales;
+	}
+	public void setRegistrosTotales(Long registrosTotales) {
+		this.registrosTotales = registrosTotales;
+	}
+	
+	@Override
+    public String toString() {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            return objectMapper.writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+        	log.error("Excepción atrapada al serializar objeto: {}", e.getMessage());
+        	return super.toString(); 
+        }
+    }
+	
+}

--- a/src/main/java/com/customer/api/dto/in/UsuarioResponse.java
+++ b/src/main/java/com/customer/api/dto/in/UsuarioResponse.java
@@ -1,0 +1,100 @@
+package com.customer.api.dto.in;
+
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@JsonInclude(Include.NON_NULL)
+public class UsuarioResponse{
+	
+	private static final Logger log = LoggerFactory.getLogger(UsuarioResponse.class);
+	
+	
+	private String nombres;
+	private String apellidos;
+	private String nombreUsuario;
+	private String correo;
+	private Set<String> roles;
+    private Boolean esActivo;
+	
+	public UsuarioResponse() {
+		super();
+	}
+
+	public UsuarioResponse(String nombres, String apellidos, String nombreUsuario, String correo, Set<String> roles,
+			Boolean esActivo) {
+		super();
+		this.nombres = nombres;
+		this.apellidos = apellidos;
+		this.nombreUsuario = nombreUsuario;
+		this.correo = correo;
+		this.roles = roles;
+		this.esActivo = esActivo;
+	}
+
+	public String getNombres() {
+		return nombres;
+	}
+
+	public void setNombres(String nombres) {
+		this.nombres = nombres;
+	}
+
+	public String getApellidos() {
+		return apellidos;
+	}
+
+	public void setApellidos(String apellidos) {
+		this.apellidos = apellidos;
+	}
+
+	public String getNombreUsuario() {
+		return nombreUsuario;
+	}
+
+	public void setNombreUsuario(String nombreUsuario) {
+		this.nombreUsuario = nombreUsuario;
+	}
+
+	public String getCorreo() {
+		return correo;
+	}
+
+	public void setCorreo(String correo) {
+		this.correo = correo;
+	}
+
+	public Set<String> getRoles() {
+		return roles;
+	}
+
+	public void setRoles(Set<String> roles) {
+		this.roles = roles;
+	}
+
+	public Boolean getEsActivo() {
+		return esActivo;
+	}
+
+	public void setEsActivo(Boolean esActivo) {
+		this.esActivo = esActivo;
+	}
+
+	@Override
+    public String toString() {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            return objectMapper.writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+        	log.error("Excepción atrapada al serializar objeto: " + e.getMessage());
+        	return super.toString(); 
+        }
+    }
+
+}

--- a/src/main/java/com/customer/api/dto/out/AuthAPIResponse.java
+++ b/src/main/java/com/customer/api/dto/out/AuthAPIResponse.java
@@ -1,0 +1,78 @@
+package com.customer.api.dto.out;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.customer.api.dto.in.UsuarioResponse;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@JsonInclude(Include.NON_EMPTY)
+public class AuthAPIResponse {
+	
+	public static final Logger log = LoggerFactory.getLogger(AuthAPIResponse.class);
+	
+	private String token;
+	private String fechaHora;
+	private List<String> detalles;
+	private List<UsuarioResponse> usuarios;
+	
+	public AuthAPIResponse() {
+		super();
+	}
+
+	public AuthAPIResponse(String token, String fechaHora, List<String> detalles) {
+		super();
+		this.token = token;
+		this.fechaHora = fechaHora;
+		this.detalles = detalles;
+	}
+
+	public String getToken() {
+		return token;
+	}
+
+	public void setToken(String token) {
+		this.token = token;
+	}
+
+	public String getFechaHora() {
+		return fechaHora;
+	}
+
+	public void setFechaHora(String fechaHora) {
+		this.fechaHora = fechaHora;
+	}
+
+	public List<String> getDetalles() {
+		return detalles;
+	}
+
+	public void setDetalles(List<String> detalles) {
+		this.detalles = detalles;
+	}
+	
+	public List<UsuarioResponse> getUsuarios() {
+		return usuarios;
+	}
+
+	public void setUsuarios(List<UsuarioResponse> usuarios) {
+		this.usuarios = usuarios;
+	}
+
+	@Override
+    public String toString() {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            return objectMapper.writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+        	log.error("Excepción atrapada al serializar objeto: {}",  e.getMessage());
+        	return super.toString(); 
+        }
+    }
+
+}

--- a/src/main/java/com/customer/api/service/DefaultAuthService.java
+++ b/src/main/java/com/customer/api/service/DefaultAuthService.java
@@ -1,0 +1,122 @@
+package com.customer.api.service;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.event.EventListener;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import com.customer.api.dto.in.AuthRequest;
+import com.customer.api.dto.out.AuthAPIResponse;
+import com.customer.util.JwtFetchEvent;
+import com.customer.util.JwtGatekeeper;
+import com.customer.util.JwtUtils;
+
+@Service
+public class DefaultAuthService implements SvcAuth {
+
+	private static final Logger log = LoggerFactory.getLogger(DefaultAuthService.class);
+
+	private static final String TOKEN_FETCH_FAILED = "El token no fue poblado correctamente. No se puede instruir la petición hacia servicio de consulta usuarios";
+
+	@Autowired
+	private RestTemplate restTemplate;
+
+	@Value("${api.auth.url}")
+	private String apiAuthUrl;
+
+	@Autowired
+	private JwtGatekeeper jwtGatekeeper;
+
+	private static final String authEndpoint = "/login";
+	private static final String getUsuarios = "/usuario";
+
+	@EventListener
+	public void fetchAndUpdateJwt(JwtFetchEvent event){
+		String newJwt = solicitaToken(event.getRequest());
+
+		if(newJwt == null || newJwt.isBlank()) {
+			jwtGatekeeper.updateJwt(null, null);
+			return;
+		}
+
+		String jwtPayload = newJwt.replace("Bearer ", "");
+		Instant expiration = JwtUtils.extractExpiration(jwtPayload);
+		jwtGatekeeper.updateJwt(newJwt, expiration);
+	}
+
+	@Override
+	public String solicitaToken(AuthRequest tokenRequest) { 
+		log.info("Obteniendo JWT para autenticación de peticiones en el sistema...");
+		String token = null;
+		ResponseEntity<AuthAPIResponse> responseAuth = null;
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON);
+		headers.setAcceptCharset(Collections.singletonList(StandardCharsets.UTF_8));
+		headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+
+		HttpEntity<String> requestEntity = new HttpEntity<>(tokenRequest.toString(), headers);
+
+		try {
+			responseAuth = restTemplate.exchange(this.apiAuthUrl + authEndpoint, HttpMethod.POST, requestEntity, AuthAPIResponse.class);
+			token = new String(responseAuth.getBody().getToken());
+		} catch (RestClientException | NullPointerException e) {
+			log.error("Error en la peticion para obtener el web token: {}", e.getMessage());
+			log.error("--------STACKTRACE--------", e.fillInStackTrace());
+			log.error("--------STACKTRACE--------");
+			return null;
+		} 
+
+		log.info("... Token recuperado");
+		return token; 
+	}
+
+
+	@Override
+	public AuthAPIResponse consultaUsuarios(AuthRequest request) throws InterruptedException {
+
+		ResponseEntity<AuthAPIResponse> responseGetUsuarios = null;
+		String tokenConsulta = jwtGatekeeper.getValidJwt(request);
+
+		if(tokenConsulta == null || tokenConsulta.isBlank()) {
+			log.error(TOKEN_FETCH_FAILED);
+			return new AuthAPIResponse();
+		}
+
+		try {
+			log.info("Instruyendo consulta de usuarios");
+			HttpHeaders headers = new HttpHeaders();
+			headers.setContentType(MediaType.APPLICATION_JSON);
+			headers.set("Accept", "*/*");
+			headers.set("Connection", "keep-alive");
+			headers.set("Accept-Encoding", "gzip,deflate,br");
+			headers.setBearerAuth(tokenConsulta);
+
+			responseGetUsuarios = restTemplate.exchange(this.apiAuthUrl + getUsuarios, HttpMethod.GET, new HttpEntity<Object>(headers), AuthAPIResponse.class);
+
+			log.info("Response: {}", responseGetUsuarios.getBody());
+
+		}catch(RestClientException ex) {
+			log.info("Excepción atrapada en envío de la solicitud. Error: {}", ex.getMessage());
+			AuthAPIResponse response = new AuthAPIResponse();
+			response.setDetalles(Arrays.asList(ex.getMessage()));
+			return response;
+		}
+
+		return responseGetUsuarios.getBody();
+	}
+
+}

--- a/src/main/java/com/customer/api/service/SvcAuth.java
+++ b/src/main/java/com/customer/api/service/SvcAuth.java
@@ -1,0 +1,11 @@
+package com.customer.api.service;
+
+import com.customer.api.dto.in.AuthRequest;
+import com.customer.api.dto.out.AuthAPIResponse;
+
+public interface SvcAuth {
+	
+	AuthAPIResponse consultaUsuarios(AuthRequest request) throws InterruptedException;
+	String solicitaToken(AuthRequest authRequest);
+	
+}

--- a/src/main/java/com/customer/config/security/SecurityConfig.java
+++ b/src/main/java/com/customer/config/security/SecurityConfig.java
@@ -27,7 +27,7 @@ public class SecurityConfig {
 		http.csrf(AbstractHttpConfigurer::disable)
 		.authorizeHttpRequests(
 				auth -> auth
-				.requestMatchers("/error", "/swagger-ui/**", "/v3/api-docs/**", "/actuator/info", "/actuator/health").permitAll()
+				.requestMatchers("/error", "/swagger-ui/**", "/v3/api-docs/**", "/actuator/info", "/actuator/health", "/secured/usuario").permitAll()
 				
 				// Region
 				.requestMatchers(HttpMethod.GET, "/region/active").hasAnyAuthority("ADMIN", "CUSTOMER")

--- a/src/main/java/com/customer/util/JwtFetchEvent.java
+++ b/src/main/java/com/customer/util/JwtFetchEvent.java
@@ -1,0 +1,27 @@
+package com.customer.util;
+
+import org.springframework.context.ApplicationEvent;
+
+import com.customer.api.dto.in.AuthRequest;
+
+public class JwtFetchEvent extends ApplicationEvent {
+
+	private static final long serialVersionUID = -8062053822630575957L;
+	
+	private AuthRequest request;
+
+	public JwtFetchEvent(Object object, AuthRequest request) {
+		super(object);
+		this.request = request;
+	}
+
+	public AuthRequest getRequest() {
+		return request;
+	}
+
+	public void setRequest(AuthRequest request) {
+		this.request = request;
+	}
+	
+	
+}

--- a/src/main/java/com/customer/util/JwtGatekeeper.java
+++ b/src/main/java/com/customer/util/JwtGatekeeper.java
@@ -1,0 +1,61 @@
+package com.customer.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+import com.customer.api.dto.in.AuthRequest;
+
+import java.time.Instant;
+import java.util.concurrent.Executors;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+@Service
+public class JwtGatekeeper {
+	
+	private static final Logger log = LoggerFactory.getLogger(JwtGatekeeper.class);
+	
+
+	private String jwtToken;
+	private Instant expirationTime;
+	private final ReentrantLock lock = new ReentrantLock();
+	private final Condition jwtAvailable = lock.newCondition();
+
+	@Autowired
+	private ApplicationEventPublisher eventPublisher;
+
+	public String getValidJwt(AuthRequest request) throws InterruptedException {
+		lock.lock();
+		try {
+			if (!isJwtValid()) {
+				log.info("Renovando JWT para operaciones que requieren autenticación/autorización en el sistema");
+				Executors.newSingleThreadExecutor().submit(() -> eventPublisher.publishEvent(new JwtFetchEvent(this, request)));
+				jwtAvailable.await();
+			}
+			return jwtToken;
+		} finally {
+			lock.unlock();
+		}
+	}
+
+	public void updateJwt(String token, Instant expiresAt) {
+		lock.lock();
+		try {
+			this.jwtToken = token;
+			this.expirationTime = expiresAt;
+			log.info("Liberando bloqueo de peticiones");
+			jwtAvailable.signalAll();
+		} finally {
+			lock.unlock();
+		}
+	}
+
+	private boolean isJwtValid() {
+		return jwtToken != null && expirationTime != null && Instant.now().isBefore(expirationTime);
+	}
+}
+
+

--- a/src/main/java/com/customer/util/JwtUtils.java
+++ b/src/main/java/com/customer/util/JwtUtils.java
@@ -1,0 +1,21 @@
+package com.customer.util;
+
+import java.time.Instant;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+
+public class JwtUtils {
+
+	private JwtUtils() {}
+
+	public static Instant extractExpiration(String jwt) {
+		int i = jwt.lastIndexOf('.');
+		String withoutSignature = jwt.substring(0, i + 1);
+		Claims claims = Jwts.parserBuilder()
+				.build()
+				.parseClaimsJwt(withoutSignature)
+				.getBody();
+
+		return claims.getExpiration().toInstant();
+	}
+}

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,12 @@
+{"properties": [
+  {
+    "name": "api.auth.url",
+    "type": "java.lang.String",
+    "description": "URL base del servicio de autenticación/autorización del sistema'"
+  },
+  {
+    "name": "app.upload.dir",
+    "type": "java.lang.String",
+    "description": "Directorio de carga de recursos?"
+  }
+]}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,12 +1,13 @@
 spring.application.name=customer
 
-spring.datasource.url=jdbc:mysql://localhost:3306/DB_CUSTOMER_DEV
-spring.datasource.username=root
+spring.datasource.url=jdbc:mysql://localhost:3306/dwb
+spring.datasource.username=carlos
 spring.datasource.password=Hola$123.,
 spring.datasource.driverClassName=com.mysql.cj.jdbc.Driver
 
 # carpeta de archivos
 app.upload.dir=uploads
+api.auth.url=http://localhost:8081
 
 # swagger
 springdoc.swagger-ui.tags-sorter=alpha


### PR DESCRIPTION
Integración de llamada a servicio de autenticación/autorización desde API customer.
Se agrega endpoint permitido de demostración de consumo de servicio externo empleando RestTemplate y con mecanismo de intento automático de actualización de JWT con credenciales ingresadas si se encuentra expirado o no se tiene uno previamente poblado. Se recomienda disminuir tiempo de vigencia de JWT en servicio auth a 1 minuto.